### PR TITLE
Input placeholder display

### DIFF
--- a/components/define-form.tsx
+++ b/components/define-form.tsx
@@ -66,7 +66,7 @@ function getPreviewParts(phrase: string): PreviewParts | null {
 }
 
 export function DefineForm() {
-  const [phrase, setPhrase] = useState("blades apply a *shear* force that");
+  const [phrase, setPhrase] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<DefineApiSuccess | null>(null);
@@ -124,7 +124,7 @@ export function DefineForm() {
             id="phrase"
             name="phrase"
             rows={3}
-            placeholder="blades apply a *shear* force that"
+            placeholder="Enter a phrase with an *esoteric* word in it"
             autoComplete="off"
             className="border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-12 w-full rounded-md border bg-transparent px-3 py-3 text-base shadow-xs outline-none resize-y overflow-auto focus-visible:ring-[3px]"
             value={phrase}


### PR DESCRIPTION
Remove default input text and update placeholder to user-specified text.

---
<p><a href="https://cursor.com/agents/bc-d853535e-24e0-4c5f-bbed-66394bb4fca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d853535e-24e0-4c5f-bbed-66394bb4fca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts initial form state and placeholder text, with no changes to API calls or data handling.
> 
> **Overview**
> Removes the pre-filled default phrase in `DefineForm`, so the textarea now starts empty.
> 
> Updates the textarea placeholder copy to prompt users to enter a phrase with an `*esoteric*` word marked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc8501e62640a7baca74ca7928d6b53e5a68df12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->